### PR TITLE
Fix Typo in config file

### DIFF
--- a/configFiles.json
+++ b/configFiles.json
@@ -8,7 +8,7 @@
 
 			"Gameplay.fGoldLossFactor": "{{server.build.env.CFG_GAME_GOLD_LOSS_FACTOR}}",			
 			"Gameplay.bEnableXpSync": "{{server.build.env.CFG_GAME_XP_SYNC}}",
-			"Gameplay.bEnablePvp": "{{server.build.env.CFG_GAME_ENALBE_PVP}}",
+			"Gameplay.bEnablePvp": "{{server.build.env.CFG_GAME_ENABLE_PVP}}",
 			"Gameplay.bEnableGreetings": "{{server.build.env.CFG_GAME_ENABLE_GREETINGS}}",
 			"Gameplay.uDifficulty": "{{server.build.env.CFG_GAME_DIFFICULTY}}",
 


### PR DESCRIPTION
server.build.env.CFG_GAME_ENABLE_PVP variable was spelt incorrectly leading to PVP not being possible to enable